### PR TITLE
Converted package.xml to format 3, added sensor_msgs as dependency for custom msgs and fixed wrong member type in Code.msg custom message

### DIFF
--- a/rover_control/CMakeLists.txt
+++ b/rover_control/CMakeLists.txt
@@ -85,6 +85,7 @@ add_message_files(
 generate_messages(
   DEPENDENCIES
   std_msgs
+  sensor_msgs
 )
 
 ################################################

--- a/rover_control/msg/Code.msg
+++ b/rover_control/msg/Code.msg
@@ -1,2 +1,2 @@
 uint8 value
-sensor_msgs/ImagePtr image
+sensor_msgs/Image image

--- a/rover_control/package.xml
+++ b/rover_control/package.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0"?>
-<package>
+<package format="1">
   <name>polyorbite_rover</name>
   <version>0.0.5</version>
   <description>polyorbite_rover</description>
   <author email="x.ouimet@gmail.com">Xavier Ouimet</author>
   <maintainer email="x.ouimet@gmail.com">Xavier Ouimet</maintainer>
-
 
   <license>BSD</license>
 
@@ -16,15 +15,7 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>message_generation</build_depend>
-  <exec_depend>message_runtime</exec_depend>
 
-
- <!--<run_depend>controller_manager</run_depend>
-
-  <run_depend>gazebo_ros</run_depend>
-  <run_depend>gazebo_ros_control</run_depend>
-
-  <run_depend>rqt_robot_steering</run_depend>-->
   <run_depend>std_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>cv_bridge</run_depend>
@@ -35,6 +26,7 @@
   <run_depend>rviz</run_depend>
   <run_depend>xacro</run_depend>
   <run_depend>nav_msgs</run_depend>
+  <run_depend>message_runtime</run_depend>
 
   <export>
 		<controller_interface plugin="${prefix}/controller_plugins.xml" />

--- a/rover_control/package.xml
+++ b/rover_control/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="1">
+<package format="3">
   <name>polyorbite_rover</name>
   <version>0.0.5</version>
   <description>polyorbite_rover</description>
@@ -9,26 +9,23 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>cv_bridge</build_depend>
+  
+  <depend>cv_bridge</depend>
+  <depend>roscpp</depend>
+  <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>nav_msgs</depend>
+
   <build_depend>image_transport</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>nav_msgs</build_depend>
   <build_depend>message_generation</build_depend>
 
-  <run_depend>std_msgs</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>cv_bridge</run_depend>
-  <run_depend>diff_drive_controller</run_depend>
-  <run_depend>joint_state_controller</run_depend>
-  <run_depend>position_controllers</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
-  <run_depend>rviz</run_depend>
-  <run_depend>xacro</run_depend>
-  <run_depend>nav_msgs</run_depend>
-  <run_depend>message_runtime</run_depend>
+  <exec_depend>diff_drive_controller</exec_depend>
+  <exec_depend>joint_state_controller</exec_depend>
+  <exec_depend>position_controllers</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rviz</exec_depend>
+  <exec_depend>xacro</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
 
   <export>
 		<controller_interface plugin="${prefix}/controller_plugins.xml" />

--- a/rover_control/package.xml
+++ b/rover_control/package.xml
@@ -13,10 +13,12 @@
   <build_depend>image_transport</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>message_generation</build_depend>
 
   <run_depend>std_msgs</run_depend>
+  <run_depend>sensor_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>cv_bridge</run_depend>
   <run_depend>diff_drive_controller</run_depend>


### PR DESCRIPTION
### What changed and why:
1. `sensor_msgs/ImagePtr` is not a valid type for a member of a ROS message, `sensor_msgs/Image` should be used instead* ;
2. Since you are using a message from package : `sensor_msgs`, it should be included in the CMakeLists file so that catkin has access to `sensor_msgs/Image` when transpiling `Code.msg` to classes ;
3. Package.xml has three formats : in format 1, one would use <run_depend> were as in format 2 it was replaced by <exec_depend> (also, \<depend\> has been added for cases were in format 1 we would have both a <run_depend> and a <build_depend> for the same dependency), Xavier used format 1 when writing this package and you used an <exec_depend> for message_runtime, I rewrote package.xml so it is compatible with format 3.

\* A ROS message contains data that you want to send to another node, so obviously sending a pointer would not do any good ; the other node would not have access to the actual image.