### PR TITLE
Feature/hw interface/cleanup and fix proposition

### DIFF
--- a/rover_control/CMakeLists.txt
+++ b/rover_control/CMakeLists.txt
@@ -1,15 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(polyorbite_rover)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
-
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
-
-
-
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   rospy
@@ -27,95 +18,6 @@ if(CATKIN_ENABLE_TESTING)
   roslaunch_add_file_check(launch)
 endif()
 
-## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
-
-
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-# catkin_python_setup()
-
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend tag for "message_generation"
-##   * add a build_depend and a exec_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
-##     but can be declared for certainty nonetheless:
-##     * add a exec_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
-## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
-
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs
-# )
-
-################################################
-## Declare ROS dynamic reconfigure parameters ##
-################################################
-
-## To declare and build dynamic reconfigure parameters within this
-## package, follow these steps:
-## * In the file package.xml:
-##   * add a build_depend and a exec_depend tag for "dynamic_reconfigure"
-## * In this file (CMakeLists.txt):
-##   * add "dynamic_reconfigure" to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * uncomment the "generate_dynamic_reconfigure_options" section below
-##     and list every .cfg file to be processed
-
-## Generate dynamic reconfigure parameters in the 'cfg' folder
-# generate_dynamic_reconfigure_options(
-#   cfg/DynReconf1.cfg
-#   cfg/DynReconf2.cfg
-# )
-
-###################################
-## catkin specific configuration ##
-###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if your package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES void
@@ -127,96 +29,26 @@ catkin_package(
 ## Build ##
 ###########
 
-## Specify additional locations of header files
-## Your package locations should be listed before other locations
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
   ${OpenCV_INCLUDE_DIRS}
 )
 
-## Declare a C++ library
-# add_library(${PROJECT_NAME}
-#   src/${PROJECT_NAME}/void.cpp
-# )
-
-## Add cmake target dependencies of the library
-## as an example, code may need to be generated before libraries
-## either from message generation or dynamic reconfigure
-# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Declare a C++ executable
-## With catkin_make all packages are built within a single CMake context
-## The recommended prefix ensures that target names across packages don't collide
 add_executable(odom src/odom.cpp)
 add_executable(hardware_interface
   src/hardware_interface_node.cpp
   src/new_hardware_interface.cpp
 )
 
-## Rename C++ executable without prefix
-## The above recommended prefix causes long target names, the following renames the
-## target back to the shorter version for ease of user use
-## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
-# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
-
-## Add cmake target dependencies of the executable
-## same as for the library above
-# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-# Specify libraries to link a library or executable target against
 target_link_libraries(odom ${catkin_LIBRARIES})
 target_link_libraries(hardware_interface ${catkin_LIBRARIES})
+
 #############
 ## Install ##
 #############
 
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# catkin_install_python(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark executables for installation
-## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_executables.html
-# install(TARGETS ${PROJECT_NAME}_node
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark libraries for installation
-## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_libraries.html
-# install(TARGETS ${PROJECT_NAME}
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
-# )
-
-## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
-
-## Mark other files for installation (e.g. launch and bag files, etc.)
-install(DIRECTORY launch rviz urdf
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
-
-#############
-## Testing ##
-#############
-
-## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_void.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
-
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)
+install(
+  DIRECTORY launch rviz urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/rover_control/CMakeLists.txt
+++ b/rover_control/CMakeLists.txt
@@ -9,6 +9,8 @@ find_package(catkin REQUIRED COMPONENTS
   image_transport
   nav_msgs
   tf
+  controller_manager
+  hardware_interface
 )
 
 find_package(OpenCV REQUIRED)

--- a/rover_control/CMakeLists.txt
+++ b/rover_control/CMakeLists.txt
@@ -35,6 +35,7 @@ include_directories(
   include
   ${catkin_INCLUDE_DIRS}
   ${OpenCV_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
 )
 
 add_executable(odom src/odom.cpp)
@@ -44,7 +45,7 @@ add_executable(hardware_interface
 )
 
 target_link_libraries(odom ${catkin_LIBRARIES})
-target_link_libraries(hardware_interface ${catkin_LIBRARIES})
+target_link_libraries(hardware_interface ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 #############
 ## Install ##

--- a/rover_control/CMakeLists.txt
+++ b/rover_control/CMakeLists.txt
@@ -130,7 +130,7 @@ catkin_package(
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
 include_directories(
-# include
+  include
   ${catkin_INCLUDE_DIRS}
   ${OpenCV_INCLUDE_DIRS}
 )
@@ -149,8 +149,10 @@ include_directories(
 ## With catkin_make all packages are built within a single CMake context
 ## The recommended prefix ensures that target names across packages don't collide
 add_executable(odom src/odom.cpp)
-
-
+add_executable(hardware_interface
+  src/hardware_interface_node.cpp
+  src/new_hardware_interface.cpp
+)
 
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the
@@ -164,6 +166,7 @@ add_executable(odom src/odom.cpp)
 
 # Specify libraries to link a library or executable target against
 target_link_libraries(odom ${catkin_LIBRARIES})
+target_link_libraries(hardware_interface ${catkin_LIBRARIES})
 #############
 ## Install ##
 #############

--- a/rover_control/config/diffdrive.yaml
+++ b/rover_control/config/diffdrive.yaml
@@ -1,9 +1,7 @@
 type: "diff_drive_controller/DiffDriveController"
 publish_rate: 50
 
-
-
-left_wheel: ['left_front_wheel_joint','left_middle_wheel_joint', 'left_back_wheel_joint']
+left_wheel: ['left_front_wheel_joint', 'left_middle_wheel_joint', 'left_back_wheel_joint']
 right_wheel: ['right_front_wheel_joint', 'right_middle_wheel_joint', 'right_back_wheel_joint']
 
 wheel_separation: 1.1
@@ -23,7 +21,7 @@ enable_odom_tf: false
 linear:
   x:
     has_velocity_limits    : true
-    max_velocity           : 1   # m/s
+    max_velocity           : 0.2   # m/s
     has_acceleration_limits: true
     max_acceleration       : 0.6   # m/s^2
 angular:
@@ -32,12 +30,3 @@ angular:
     max_velocity           : 2.0   # rad/s
     has_acceleration_limits: true
     max_acceleration       : 6.0   # rad/s^2
-
-/gazebo_ros_control/pid_gains:
-      left_front_wheel_joint: {p: 1.0, i: 0.0, d: 1.0}
-      left_middle_wheel_joint: {p: 1.0, i: 0.0, d: 1.0}
-      left_back_wheel_joint: {p: 1.0, i: 0.0, d: 1.0}
-      right_front_wheel_joint: {p: 1.0, i: 0.0, d: 1.0}
-      right_middle_wheel_joint: {p: 1.0, i: 0.0, d: 1.0}
-      right_back_wheel_joint: {p: 1.0, i: 0.0, d: 1.0}
-

--- a/rover_control/include/new_hardware_interface.h
+++ b/rover_control/include/new_hardware_interface.h
@@ -15,8 +15,9 @@ public:
   MyRobot(ros::NodeHandle nh, double frequency = DEFAULT_FREQUENCY);
 
   void readMotorData();
-
   void writeMotorData();
+
+  double velocityToPwm(const double& velocity);
 
 private:
   ros::NodeHandle nh_;

--- a/rover_control/include/new_hardware_interface.h
+++ b/rover_control/include/new_hardware_interface.h
@@ -16,7 +16,7 @@ public:
 
   void readMotorData();
 
-  void writeMotorData(const std_msgs::Int32MultiArray command[16]);
+  void writeMotorData();
 
 private:
   ros::NodeHandle nh_;

--- a/rover_control/include/new_hardware_interface.h
+++ b/rover_control/include/new_hardware_interface.h
@@ -21,6 +21,9 @@ public:
 private:
   ros::NodeHandle nh_;
 
+  // Publishers
+  ros::Publisher velocity_pub;
+
   // Control interfaces
   hardware_interface::JointStateInterface joint_state_interface_;
   hardware_interface::VelocityJointInterface velocity_joint_interface_;

--- a/rover_control/include/new_hardware_interface.h
+++ b/rover_control/include/new_hardware_interface.h
@@ -5,7 +5,7 @@
 #include <hardware_interface/robot_hw.h>
 #include <hardware_interface/joint_state_interface.h>
 #include <hardware_interface/joint_command_interface.h>
-#include <std_msgs/Int32MultiArray>
+#include <std_msgs/Int32MultiArray.h>
 
 class MyRobot : public hardware_interface::RobotHW
 {

--- a/rover_control/include/new_hardware_interface.h
+++ b/rover_control/include/new_hardware_interface.h
@@ -7,10 +7,12 @@
 #include <hardware_interface/joint_command_interface.h>
 #include <std_msgs/Int32MultiArray.h>
 
+#define DEFAULT_FREQUENCY 16
+
 class MyRobot : public hardware_interface::RobotHW
 {
 public:
-  MyRobot(ros::NodeHandle nh, double frequency);
+  MyRobot(ros::NodeHandle nh, double frequency = DEFAULT_FREQUENCY);
 
   void readMotorData();
 

--- a/rover_control/launch/control.launch
+++ b/rover_control/launch/control.launch
@@ -4,7 +4,6 @@
   <arg name="rvizconfig" default="$(find polyorbite_rover)/rviz/urdf.rviz" />
   <arg name="world" default="$(find polyorbite_rover)/worlds/maze2.world" />
 
-
   <!-- Launch Gazebo -->
   <include file="$(find polyorbite_rover)/launch/gazebo.launch">
     <arg name="model" value="$(arg model)" />
@@ -26,7 +25,7 @@
             file="$(find polyorbite_rover)/config/joints.yaml"
             ns="rover_joint_state_controller" />
   <rosparam command="load"
-            file="$(find urdf_sim_tutorial)/config/diffdrive.yaml"
+            file="$(find polyorbite_rover)/config/diffdrive.yaml"
             ns="rover_diff_drive_controller" />
 
 

--- a/rover_control/launch/control_physical.launch
+++ b/rover_control/launch/control_physical.launch
@@ -1,0 +1,40 @@
+<?xml version="1.0" ?>
+<launch>
+  <param name="robot_description"
+         command="$(find xacro)/xacro --inorder '$(find polyorbite_rover)/urdf/rover1.urdf.xacro'" />
+
+  <node name="hardware_interface"
+        type="hardware_interface"
+        pkg="polyorbite_rover"
+        ns="rover_diff_drive_controller" />
+
+  <!-- Système de localisation -->
+  <include file="$(find polyorbite_rover)/launch/robot_localization_ekf.launch">
+  </include>
+  
+  <!-- Contrôleur des roues -->
+  <rosparam command="load"
+            file="$(find polyorbite_rover)/config/joints.yaml"
+            ns="rover_joint_state_controller" />
+  <rosparam command="load"
+            file="$(find polyorbite_rover)/config/diffdrive.yaml"
+            ns="rover_diff_drive_controller" />
+
+  <!-- Spawn les contrôleurs -->
+  <node name="controller_spawner"
+        pkg="controller_manager"
+        type="spawner"
+        args="rover_joint_state_controller
+              rover_diff_drive_controller"
+        output="screen"/>
+  
+  <!-- Contrôleur des roues gui-->
+  <node name="rqt_robot_steering" pkg="rqt_robot_steering" type="rqt_robot_steering">
+    <param name="default_topic" value="/rover_diff_drive_controller/cmd_vel"/>
+  </node>
+
+
+  <!-- Rotation et transformation des deux caméras -->
+  <node pkg="tf2_ros" type="static_transform_publisher" name="left_cam_rotation" args="0 0 0 0.5 -0.5  0.5  -0.5 camera_left_link left_cam_rotated" />
+  <node pkg="tf2_ros" type="static_transform_publisher" name="right_cam_rotation" args="0 0 0 0.5 -0.5  0.5  -0.5 camera_right_link right_cam_rotated" />
+</launch>

--- a/rover_control/src/hardware_interface_node.cpp
+++ b/rover_control/src/hardware_interface_node.cpp
@@ -1,4 +1,4 @@
-#include "new_hardware_interface"
+#include "new_hardware_interface.h"
 
 int main(int argc, char **argv)
 {

--- a/rover_control/src/hardware_interface_node.cpp
+++ b/rover_control/src/hardware_interface_node.cpp
@@ -1,6 +1,9 @@
-#include "controller_manager/controller_manager.h"
+#include <boost/chrono.hpp>
 
+#include "controller_manager/controller_manager.h"
 #include "new_hardware_interface.h"
+
+typedef boost::chrono::steady_clock time_source;
 
 int main(int argc, char **argv)
 {
@@ -13,11 +16,17 @@ int main(int argc, char **argv)
   MyRobot myHWInterface(nh);
   controller_manager::ControllerManager cm(&myHWInterface);
 
+  time_source::time_point lastTime = time_source::now();
+
   // While this hardware interface is active
   while (ros::ok())
   {
+    time_source::time_point currentTime = time_source::now();
+    boost::chrono::duration<double> elapsedTime = currentTime - lastTime;
+    lastTime = currentTime;
+
     myHWInterface.readMotorData();  //TBD
-    cm.update(myHWInterface.getTime(), myHWInterface.getPeriod());
+    cm.update(ros::Time::now(), (ros::Duration)(elapsedTime.count()));
     myHWInterface.writeMotorData();
 
     rate.sleep();

--- a/rover_control/src/hardware_interface_node.cpp
+++ b/rover_control/src/hardware_interface_node.cpp
@@ -1,3 +1,5 @@
+#include "controller_manager/controller_manager.h"
+
 #include "new_hardware_interface.h"
 
 int main(int argc, char **argv)

--- a/rover_control/src/new_hardware_interface.cpp
+++ b/rover_control/src/new_hardware_interface.cpp
@@ -1,8 +1,6 @@
 #include "new_hardware_interface.h"
 
-MyRobot::MyRobot(ros::NodeHandle nh)
-  :
-  nh_(nh)
+MyRobot::MyRobot(ros::NodeHandle nh) : nh_(nh)
 {
   // connect and register the JointStateInterface (hard coded)
   hardware_interface::JointStateHandle state_handle_front_left("FL", &pos[0], &vel[0], &eff[0]);

--- a/rover_control/src/new_hardware_interface.cpp
+++ b/rover_control/src/new_hardware_interface.cpp
@@ -6,33 +6,33 @@ MyRobot::MyRobot(ros::NodeHandle nh, double frequency) : nh_(nh)
   velocity_pub = nh.advertise<std_msgs::Int32MultiArray>("command", 1000);  // https://github.com/dheera/ros-pwm-pca9685
 
   // connect and register the JointStateInterface (hard coded)
-  hardware_interface::JointStateHandle state_handle_front_left("FL", &pos[0], &vel[0], &eff[0]);
+  hardware_interface::JointStateHandle state_handle_front_left("left_front_wheel_joint", &pos[0], &vel[0], &eff[0]);
   joint_state_interface_.registerHandle(state_handle_front_left);
-  hardware_interface::JointStateHandle state_handle_front_right("FR", &pos[1], &vel[1], &eff[1]);
+  hardware_interface::JointStateHandle state_handle_front_right("right_front_wheel_joint", &pos[1], &vel[1], &eff[1]);
   joint_state_interface_.registerHandle(state_handle_front_right);
-  hardware_interface::JointStateHandle state_handle_middle_left("ML", &pos[2], &vel[2], &eff[2]);
+  hardware_interface::JointStateHandle state_handle_middle_left("left_middle_wheel_joint", &pos[2], &vel[2], &eff[2]);
   joint_state_interface_.registerHandle(state_handle_middle_left);
-  hardware_interface::JointStateHandle state_handle_middle_right("MR", &pos[3], &vel[3], &eff[3]);
+  hardware_interface::JointStateHandle state_handle_middle_right("right_middle_wheel_joint", &pos[3], &vel[3], &eff[3]);
   joint_state_interface_.registerHandle(state_handle_middle_right);
-  hardware_interface::JointStateHandle state_handle_back_left("BL", &pos[4], &vel[4], &eff[4]);
+  hardware_interface::JointStateHandle state_handle_back_left("left_back_wheel_joint", &pos[4], &vel[4], &eff[4]);
   joint_state_interface_.registerHandle(state_handle_back_left);
-  hardware_interface::JointStateHandle state_handle_back_right("BR", &pos[5], &vel[5], &eff[5]);
+  hardware_interface::JointStateHandle state_handle_back_right("right_back_wheel_joint", &pos[5], &vel[5], &eff[5]);
   joint_state_interface_.registerHandle(state_handle_back_right);
 
   registerInterface(&joint_state_interface_);
 
   // connect and register the velocity joint interface
-  hardware_interface::JointHandle vel_handle_front_left(joint_state_interface_.getHandle("FL"), &cmd[0]);
+  hardware_interface::JointHandle vel_handle_front_left(joint_state_interface_.getHandle("left_front_wheel_joint"), &cmd[0]);
   velocity_joint_interface_.registerHandle(vel_handle_front_left);
-  hardware_interface::JointHandle vel_handle_front_right(joint_state_interface_.getHandle("FR"), &cmd[1]);
+  hardware_interface::JointHandle vel_handle_front_right(joint_state_interface_.getHandle("right_front_wheel_joint"), &cmd[1]);
   velocity_joint_interface_.registerHandle(vel_handle_front_right);
-  hardware_interface::JointHandle vel_handle_middle_left(joint_state_interface_.getHandle("ML"), &cmd[2]);
+  hardware_interface::JointHandle vel_handle_middle_left(joint_state_interface_.getHandle("left_middle_wheel_joint"), &cmd[2]);
   velocity_joint_interface_.registerHandle(vel_handle_middle_left);
-  hardware_interface::JointHandle vel_handle_middle_right(joint_state_interface_.getHandle("MR"), &cmd[3]);
+  hardware_interface::JointHandle vel_handle_middle_right(joint_state_interface_.getHandle("right_middle_wheel_joint"), &cmd[3]);
   velocity_joint_interface_.registerHandle(vel_handle_middle_right);
-  hardware_interface::JointHandle vel_handle_back_left(joint_state_interface_.getHandle("BL"), &cmd[4]);
+  hardware_interface::JointHandle vel_handle_back_left(joint_state_interface_.getHandle("left_back_wheel_joint"), &cmd[4]);
   velocity_joint_interface_.registerHandle(vel_handle_back_left);
-  hardware_interface::JointHandle vel_handle_back_right(joint_state_interface_.getHandle("BR"), &cmd[5]);
+  hardware_interface::JointHandle vel_handle_back_right(joint_state_interface_.getHandle("right_back_wheel_joint"), &cmd[5]);
   velocity_joint_interface_.registerHandle(vel_handle_back_right);
 
   registerInterface(&velocity_joint_interface_);

--- a/rover_control/src/new_hardware_interface.cpp
+++ b/rover_control/src/new_hardware_interface.cpp
@@ -41,7 +41,7 @@ MyRobot::MyRobot(ros::NodeHandle nh, double frequency) : nh_(nh)
 void MyRobot::readMotorData()  // This function connects to the node that will subscribe to the correct topic for obtaining the velocity or voltage values
 {
 
-  //ROS_INFO_STREAM("Received velocity information from Robot!");  // en attente de connaitre a quoi se subscribe
+  // En attente de connaitre a quoi se subscribe
 }
 
 void MyRobot::writeMotorData()
@@ -50,17 +50,19 @@ void MyRobot::writeMotorData()
   // Methode interessante: https://answers.ros.org/question/353861/why-my-hardware-interface-cant-get-command-from-controller/
   
   std_msgs::Int32MultiArray pwmValues;
-  pwmValues.data.push_back(velocityToPwm(vel[0]));
-  pwmValues.data.push_back(velocityToPwm(vel[1]));
-  pwmValues.data.push_back(velocityToPwm(vel[2]));
-  pwmValues.data.push_back(velocityToPwm(vel[3]));
-  pwmValues.data.push_back(velocityToPwm(vel[4]));
-  pwmValues.data.push_back(velocityToPwm(vel[5]));
+  
+  for(double wantedVelocity : cmd)
+  {
+    pwmValues.data.push_back(velocityToPwm(wantedVelocity));
+  }
+  
   velocity_pub.publish(pwmValues);
-  ROS_INFO("Velocity: %f", vel[0]);
-  //ROS_INFO_STREAM("Velocity information sent from Robot!");
-}
 
+  ROS_INFO("pos: [%f, %f, %f, %f, %f, %f]", pos[0], pos[1], pos[2], pos[3], pos[4], pos[5]);
+  ROS_INFO("vec: [%f, %f, %f, %f, %f, %f]", vel[0], vel[1], vel[2], vel[3], vel[4], vel[5]);
+  ROS_INFO("eff: [%f, %f, %f, %f, %f, %f]", eff[0], eff[1], eff[2], eff[3], eff[4], eff[5]);
+  ROS_INFO("cmd: [%f, %f, %f, %f, %f, %f]", cmd[0], cmd[1], cmd[2], cmd[3], cmd[4], cmd[5]);
+}
 
 double MyRobot::velocityToPwm(const double& velocity)
 {

--- a/rover_control/src/new_hardware_interface.cpp
+++ b/rover_control/src/new_hardware_interface.cpp
@@ -41,19 +41,28 @@ MyRobot::MyRobot(ros::NodeHandle nh, double frequency) : nh_(nh)
 void MyRobot::readMotorData()  // This function connects to the node that will subscribe to the correct topic for obtaining the velocity or voltage values
 {
 
-  ROS_INFO_STREAM("Received velocity information from Robot!");  // en attente de connaitre a quoi se subscribe
+  //ROS_INFO_STREAM("Received velocity information from Robot!");  // en attente de connaitre a quoi se subscribe
 }
 
 void MyRobot::writeMotorData()
 {
-  ros::Rate loop_rate(10);
-
   // Publish the velocity commands while this node is active
   // Methode interessante: https://answers.ros.org/question/353861/why-my-hardware-interface-cant-get-command-from-controller/
   
   std_msgs::Int32MultiArray pwmValues;
+  pwmValues.data.push_back(velocityToPwm(vel[0]));
+  pwmValues.data.push_back(velocityToPwm(vel[1]));
+  pwmValues.data.push_back(velocityToPwm(vel[2]));
+  pwmValues.data.push_back(velocityToPwm(vel[3]));
+  pwmValues.data.push_back(velocityToPwm(vel[4]));
+  pwmValues.data.push_back(velocityToPwm(vel[5]));
   velocity_pub.publish(pwmValues);
-  ROS_INFO_STREAM("Velocity information sent from Robot!");
+  ROS_INFO("Velocity: %f", vel[0]);
+  //ROS_INFO_STREAM("Velocity information sent from Robot!");
+}
 
-  loop_rate.sleep();
+
+double MyRobot::velocityToPwm(const double& velocity)
+{
+  return velocity;
 }

--- a/rover_control/src/new_hardware_interface.cpp
+++ b/rover_control/src/new_hardware_interface.cpp
@@ -44,25 +44,16 @@ void MyRobot::readMotorData()  // This function connects to the node that will s
   ROS_INFO_STREAM("Received velocity information from Robot!");  // en attente de connaitre a quoi se subscribe
 }
 
-void MyRobot::writeMotorData(const std_msgs::Int32MultiArray command[16])
+void MyRobot::writeMotorData()
 {
-  // // Initialize the "subscriber node"
-  // ros::init(argc, argv, "velocity_pub");  // a tester, pas certain que ca fonctionne d'initialiser une node ROS dans une fonction de classe
-  // ros::NodeHandle n;
-
   ros::Rate loop_rate(10);
 
   // Publish the velocity commands while this node is active
   // Methode interessante: https://answers.ros.org/question/353861/why-my-hardware-interface-cant-get-command-from-controller/
-  while (ros::ok())
-  {
-    velocity_pub.publish(command);
-    ROS_INFO_STREAM("Velocity information sent from Robot!");
-  }
+  
+  std_msgs::Int32MultiArray pwmValues;
+  velocity_pub.publish(pwmValues);
+  ROS_INFO_STREAM("Velocity information sent from Robot!");
 
-  // Add a spinOnce for callbacks (future development)
-  ros::spinOnce();
   loop_rate.sleep();
-
-
 }

--- a/rover_control/src/new_hardware_interface.cpp
+++ b/rover_control/src/new_hardware_interface.cpp
@@ -2,6 +2,9 @@
 
 MyRobot::MyRobot(ros::NodeHandle nh, double frequency) : nh_(nh)
 {
+  // Create publisher
+  velocity_pub = nh.advertise<std_msgs::Int32MultiArray>("command", 1000);  // https://github.com/dheera/ros-pwm-pca9685
+
   // connect and register the JointStateInterface (hard coded)
   hardware_interface::JointStateHandle state_handle_front_left("FL", &pos[0], &vel[0], &eff[0]);
   joint_state_interface_.registerHandle(state_handle_front_left);
@@ -47,8 +50,6 @@ void MyRobot::writeMotorData(const std_msgs::Int32MultiArray command[16])
   // ros::init(argc, argv, "velocity_pub");  // a tester, pas certain que ca fonctionne d'initialiser une node ROS dans une fonction de classe
   // ros::NodeHandle n;
 
-  // Create the publisher
-  ros::Publisher velocity_pub = nh.advertise<std_msgs::Int32MultiArray>("command", 1000);  // https://github.com/dheera/ros-pwm-pca9685
   ros::Rate loop_rate(10);
 
   // Publish the velocity commands while this node is active

--- a/rover_control/src/new_hardware_interface.cpp
+++ b/rover_control/src/new_hardware_interface.cpp
@@ -4,7 +4,7 @@ MyRobot::MyRobot(ros::NodeHandle nh, double frequency) : nh_(nh)
 {
   // connect and register the JointStateInterface (hard coded)
   hardware_interface::JointStateHandle state_handle_front_left("FL", &pos[0], &vel[0], &eff[0]);
-  joint_state_interface_.registerHandle(state_handle_front_l);
+  joint_state_interface_.registerHandle(state_handle_front_left);
   hardware_interface::JointStateHandle state_handle_front_right("FR", &pos[1], &vel[1], &eff[1]);
   joint_state_interface_.registerHandle(state_handle_front_right);
   hardware_interface::JointStateHandle state_handle_middle_left("ML", &pos[2], &vel[2], &eff[2]);

--- a/rover_control/src/new_hardware_interface.cpp
+++ b/rover_control/src/new_hardware_interface.cpp
@@ -1,6 +1,6 @@
 #include "new_hardware_interface.h"
 
-MyRobot::MyRobot(ros::NodeHandle nh) : nh_(nh)
+MyRobot::MyRobot(ros::NodeHandle nh, double frequency) : nh_(nh)
 {
   // connect and register the JointStateInterface (hard coded)
   hardware_interface::JointStateHandle state_handle_front_left("FL", &pos[0], &vel[0], &eff[0]);


### PR DESCRIPTION
### Here is what changed:
1. Declared executable in CMakeLists for the hardware interface -> otherwise, the HW interface node will never be compiled ;
2. Fixed some include statements that were not written properly (no .h) ;
3. Fixed inconsistent constructor (had frequency in the declaration but not in the definition) ;
4. Added include statement for the controller_manager ;
5. Removed parameter from writeMotorData method (it should take its input from the values of the cmd[] array) ;
6. Removed node definition from writeMotorData (if you do ros::spin in this function, it will block the whole program and your main loop that calls writeMotorData will never continue, it is okay to define a publisher and use it in writeMotorData, but you shouldn't create a new node in an iteration of a synchronous loop) ;
7. Publisher is now initialized in the constructor (does not make sense to create and destroy the publisher handle on every iteration of the main loop) ;
8. Added controller_manager and hardware_interface to required dependencies in CMakeLists ;
9. Added boost include and library directories to CMakeLists ;
10. Added a method to convert from velocity value (values of cmd[] array) to pwm value which we want to send, the function is not implemented yet, but it exists ;
11. Fixed control.launch was not using the right configuration file for diff. drive controller ;
12. Changed the joint names in the HW interface class so they reflect those defined in diff. drive configuration ;
13. Created a new launch file that does not start up gazebo and starts the hardware interface node instead, it is called control_physical.launch .